### PR TITLE
Update ActiveRecord and other dependencies

### DIFF
--- a/activerecord-opentracing.gemspec
+++ b/activerecord-opentracing.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'opentracing_test_tracer', '~> 0.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.54.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.24.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.13'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
+  spec.add_development_dependency 'rubocop', '~> 0.78.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
+  spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 
-  spec.add_dependency 'activerecord', '~> 5.0'
-  spec.add_dependency 'opentracing', '~> 0.3'
+  spec.add_dependency 'activerecord', '~> 6.0'
+  spec.add_dependency 'opentracing', '~> 0.5'
 end

--- a/lib/active_record/opentracing/processor.rb
+++ b/lib/active_record/opentracing/processor.rb
@@ -3,10 +3,10 @@
 module ActiveRecord
   module OpenTracing
     class Processor
-      DEFAULT_OPERATION_NAME = 'sql.query'.freeze
-      COMPONENT_NAME = 'ActiveRecord'.freeze
-      SPAN_KIND = 'client'.freeze
-      DB_TYPE = 'sql'.freeze
+      DEFAULT_OPERATION_NAME = 'sql.query'
+      COMPONENT_NAME = 'ActiveRecord'
+      SPAN_KIND = 'client'
+      DB_TYPE = 'sql'
 
       def initialize(tracer)
         @tracer = tracer
@@ -31,8 +31,8 @@ module ActiveRecord
           span.set_tag('error', true)
           span.log_kv(
             event: 'error',
-            :'error.kind' => exception.class.to_s,
-            :'error.object' => exception,
+            'error.kind': exception.class.to_s,
+            'error.object': exception,
             message: exception.message,
             stack: exception.backtrace.join("\n")
           )

--- a/lib/active_record/opentracing/version.rb
+++ b/lib/active_record/opentracing/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module OpenTracing
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.1'
   end
 end

--- a/lib/active_record/opentracing/version.rb
+++ b/lib/active_record/opentracing/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module OpenTracing
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/active_record/opentracing_spec.rb
+++ b/spec/active_record/opentracing_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe ActiveRecord::OpenTracing do
     SQL
   end
 
+  # rubocop:disable RSpec/LeakyConstantDeclaration
   class User < ActiveRecord::Base
   end
+  # rubocop:enable RSpec/LeakyConstantDeclaration
 
   it 'records sql select query' do
     User.first # load table schema, etc
@@ -95,8 +97,8 @@ RSpec.describe ActiveRecord::OpenTracing do
     expect(span.logs).to include(
       a_hash_including(
         event: 'error',
-        :'error.kind' => thrown_exception.class.to_s,
-        :'error.object' => thrown_exception,
+        'error.kind': thrown_exception.class.to_s,
+        'error.object': thrown_exception,
         message: thrown_exception.message,
         stack: thrown_exception.backtrace.join("\n")
       )


### PR DESCRIPTION
- Updated ActiveRecord `5.0` -> `6.0`
- Updated Opentracing `0.3` -> `0.5`
- Updated development dependencies and bring code up to speed with new
rubocop rules.