### PR TITLE
Update activerecord due to CVE-2021-22880

### DIFF
--- a/activerecord-opentracing.gemspec
+++ b/activerecord-opentracing.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.2.9'
   spec.add_development_dependency 'opentracing_test_tracer', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 
-  spec.add_dependency 'activerecord', '~> 6.0'
+  spec.add_dependency 'activerecord', '~> 6.1'
   spec.add_dependency 'opentracing', '~> 0.5'
 end

--- a/lib/active_record/opentracing/processor.rb
+++ b/lib/active_record/opentracing/processor.rb
@@ -49,7 +49,7 @@ module ActiveRecord
 
       def db_address
         @db_address ||= begin
-          connection_config = ActiveRecord::Base.connection_config
+          connection_config = db_config
           username = connection_config[:username]
           host = connection_config[:host]
           database = connection_config.fetch(:database)
@@ -65,7 +65,7 @@ module ActiveRecord
       end
 
       def db_config
-        @db_config ||= ActiveRecord::Base.connection_config
+        @db_config ||= ActiveRecord::Base.connection_db_config.configuration_hash
       end
     end
   end

--- a/lib/active_record/opentracing/version.rb
+++ b/lib/active_record/opentracing/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module OpenTracing
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
- ActiveRecord '6.0' -> '6.1'
- Fix deprecation warning about ActiveRecord::Base.connection_config

More info: https://groups.google.com/g/rubyonrails-security/c/ZzUqCh9vyhI?pli=1