### PR TITLE
Support Rails 7 alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
   - 2.5
   - 2.6
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,16 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.1
-before_install: gem install bundler -v 1.16.2
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
+
+matrix:
+  fast_finish: true
+
+before_install:
+  - gem update --system
+  - gem install bundler
+
+script: "rake"

--- a/activerecord-opentracing.gemspec
+++ b/activerecord-opentracing.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
   spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 
-  spec.add_dependency 'activerecord', '~> 6.1'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 7.0.0
   spec.add_dependency 'opentracing', '~> 0.5'
 end


### PR DESCRIPTION
closes #6 

- add test matrix (Rails 6.1 requires Ruby >= 2.5)
- loosen requirement on activerecord