### PR TITLE
Support rails 7.0.0

### DIFF
--- a/activerecord-opentracing.gemspec
+++ b/activerecord-opentracing.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.2.9'
+  spec.add_development_dependency 'bundler', '~> 2.2.33'
   spec.add_development_dependency 'opentracing_test_tracer', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.78.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.37.0'
+  spec.add_development_dependency 'rubocop', '~> 1.23.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.37.1'
   spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 7.0.0'
+  spec.add_dependency 'activerecord', '>= 6.1'
   spec.add_dependency 'opentracing', '~> 0.5'
 end


### PR DESCRIPTION
Hi :wave: 

As Rails 7.0.0 has been released 2 days ago, I've changed the dependency to accept the `7.0.0` for activerecord.
I've also updated the versions of `bundler`, `rubocop` and `rubocop-rspec`.



